### PR TITLE
Discussion feed sign in fix

### DIFF
--- a/EmbeddedSocialClient/sdk/build.gradle
+++ b/EmbeddedSocialClient/sdk/build.gradle
@@ -126,7 +126,7 @@ clearOutputFolder()
 
 def siteUrl = 'https://github.com/Microsoft/EmbeddedSocial-Android-SDK'
 def gitUrl = 'https://github.com/Microsoft/EmbeddedSocial-Android-SDK.git'
-def versionNum = '0.0.29'
+def versionNum = '0.0.31'
 group = "com.acrowntest.test"
 version = versionNum
 

--- a/EmbeddedSocialClient/sdk/src/main/java/com/microsoft/embeddedsocial/ui/fragment/DiscussionFeedFragment.java
+++ b/EmbeddedSocialClient/sdk/src/main/java/com/microsoft/embeddedsocial/ui/fragment/DiscussionFeedFragment.java
@@ -74,6 +74,7 @@ public abstract class DiscussionFeedFragment extends BaseListContentFragment<Dis
 	private PhotoProviderModule photoProvider;
 	private Uri imageUri;
 	private Activity mActivity;
+	private boolean isSignedIn;
 
 	private ProfileInfoRenderer.ProfileViewHolder profileViewHolder;
 
@@ -91,6 +92,7 @@ public abstract class DiscussionFeedFragment extends BaseListContentFragment<Dis
 	public void onAttach(Activity activity) {
 		super.onAttach(activity);
 		mActivity = activity;
+		isSignedIn = UserAccount.getInstance().isSignedIn();
 	}
 
 	protected DiscussionFeedFragment() {
@@ -220,12 +222,17 @@ public abstract class DiscussionFeedFragment extends BaseListContentFragment<Dis
 	@Override
 	public void onResume() {
 		super.onResume();
+		// Check if the user has signed in since the last time this fragment was shown
+		if (!isSignedIn && UserAccount.getInstance().isSignedIn()) {
+			onUserSignedIn();
+		}
 		EventBus.register(eventListener);
 	}
 
 	@Override
 	public void onUserSignedIn() {
 		initRecyclerView();
+		isSignedIn = true;
 	}
 
 	@Override


### PR DESCRIPTION
Fixed a bug in the discussion feed fragment where a user could sign in when viewing a reply feed, hit the back button, and the comment feed fragment would not know the user was authenticated.