### PR TITLE
Add the option to remove the navigation drawer from the SignIn page

### DIFF
--- a/EmbeddedSocialClient/sdk/src/main/java/com/microsoft/embeddedsocial/ui/activity/SignInActivity.java
+++ b/EmbeddedSocialClient/sdk/src/main/java/com/microsoft/embeddedsocial/ui/activity/SignInActivity.java
@@ -18,6 +18,8 @@ import android.content.Intent;
  * Activity for sign-in.
  */
 public class SignInActivity extends BaseActivity {
+	public static final String NAME = "SignIn";
+
 	private SignInFragment signInFragment;
 
 	public SignInActivity() {
@@ -33,6 +35,11 @@ public class SignInActivity extends BaseActivity {
 	@Override
 	protected boolean isAuthorizationRequired() {
 		return false;
+	}
+
+	@Override
+	protected String getName() {
+		return NAME;
 	}
 
 	@Override


### PR DESCRIPTION
SignIn was previously missing from the list of activities that could remove the navigation drawer via configuration settings