### PR TITLE
Set ContinuationKey for Feed Responses/Fetchers; Set DeliveredActivityHandle properly to update read notifications

### DIFF
--- a/EmbeddedSocialClient/sdk/build.gradle
+++ b/EmbeddedSocialClient/sdk/build.gradle
@@ -103,6 +103,7 @@ dependencies {
     compile 'com.github.chrisbanes.photoview:library:1.2.3'
     compile 'com.squareup.retrofit2:converter-gson:2.0.0-beta4'
     compile 'com.acrowntest.test:autorest:0.0.8'
+    compile 'org.jetbrains:annotations:15.0'
 }
 
 retrolambda {

--- a/EmbeddedSocialClient/sdk/src/main/java/com/microsoft/embeddedsocial/server/model/FeedUserResponse.java
+++ b/EmbeddedSocialClient/sdk/src/main/java/com/microsoft/embeddedsocial/server/model/FeedUserResponse.java
@@ -10,14 +10,14 @@ package com.microsoft.embeddedsocial.server.model;
  */
 public class FeedUserResponse {
 
-	private String continuationKey;
+    private String continuationKey;
 
-	public String getContinuationKey() {
-		return continuationKey;
-	}
-	
+    public String getContinuationKey() {
+        return continuationKey;
+    }
+
     public void setContinuationKey(String continuationKey) {
-		this.continuationKey = continuationKey;
-	}
+        this.continuationKey = continuationKey;
+    }
 
 }

--- a/EmbeddedSocialClient/sdk/src/main/java/com/microsoft/embeddedsocial/server/model/FeedUserResponse.java
+++ b/EmbeddedSocialClient/sdk/src/main/java/com/microsoft/embeddedsocial/server/model/FeedUserResponse.java
@@ -15,4 +15,9 @@ public class FeedUserResponse {
 	public String getContinuationKey() {
 		return continuationKey;
 	}
+	
+    public void setContinuationKey(String continuationKey) {
+		this.continuationKey = continuationKey;
+	}
+
 }

--- a/EmbeddedSocialClient/sdk/src/main/java/com/microsoft/embeddedsocial/server/model/notification/GetNotificationFeedResponse.java
+++ b/EmbeddedSocialClient/sdk/src/main/java/com/microsoft/embeddedsocial/server/model/notification/GetNotificationFeedResponse.java
@@ -10,6 +10,8 @@ import com.microsoft.embeddedsocial.server.model.view.ActivityView;
 import com.microsoft.embeddedsocial.autorest.models.FeedResponseActivityView;
 import com.microsoft.embeddedsocial.server.model.FeedUserResponse;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -20,13 +22,21 @@ public class GetNotificationFeedResponse extends FeedUserResponse implements Lis
     // Setting this handle is required to properly update the "last-read" notification
     private String deliveredActivityHandle;
 
-    public GetNotificationFeedResponse(List<ActivityView> activities) {
+    public GetNotificationFeedResponse(@NotNull List<ActivityView> activities) {
         this.activities = activities;
+        if (activities == null) {
+            this.deliveredActivityHandle = "";
+            return;
+        }
         this.deliveredActivityHandle = (activities.isEmpty() ? "" : activities.get(0).getHandle());
     }
 
-    public GetNotificationFeedResponse(FeedResponseActivityView response) {
+    public GetNotificationFeedResponse(@NotNull FeedResponseActivityView response) {
         activities = new ArrayList<>();
+        if (response == null) {
+            this.deliveredActivityHandle = "";
+            return;
+        }
         for (com.microsoft.embeddedsocial.autorest.models.ActivityView view : response.getData()) {
             activities.add(new ActivityView(view));
         }

--- a/EmbeddedSocialClient/sdk/src/main/java/com/microsoft/embeddedsocial/server/model/notification/GetNotificationFeedResponse.java
+++ b/EmbeddedSocialClient/sdk/src/main/java/com/microsoft/embeddedsocial/server/model/notification/GetNotificationFeedResponse.java
@@ -16,31 +16,31 @@ import java.util.List;
 
 public class GetNotificationFeedResponse extends FeedUserResponse implements ListResponse<ActivityView> {
 
-	private List<ActivityView> activities;
-	// Setting this handle is required to properly update the "last-read" notification
-	private String deliveredActivityHandle;
+    private List<ActivityView> activities;
+    // Setting this handle is required to properly update the "last-read" notification
+    private String deliveredActivityHandle;
 
-	public GetNotificationFeedResponse(List<ActivityView> activities) {
-		this.activities = activities;
-		this.deliveredActivityHandle = (activities.isEmpty() ? "" : activities.get(0).getHandle());
-	}
+    public GetNotificationFeedResponse(List<ActivityView> activities) {
+        this.activities = activities;
+        this.deliveredActivityHandle = (activities.isEmpty() ? "" : activities.get(0).getHandle());
+    }
 
-	public GetNotificationFeedResponse (FeedResponseActivityView response) {
-		activities = new ArrayList<>();
-		for (com.microsoft.embeddedsocial.autorest.models.ActivityView view : response.getData()) {
-			activities.add(new ActivityView(view));
-		}
-		// Update the deliveredActivityHandle to be the most recent activity handle
-		this.deliveredActivityHandle = (activities.isEmpty() ? "" : activities.get(0).getHandle());
+    public GetNotificationFeedResponse(FeedResponseActivityView response) {
+        activities = new ArrayList<>();
+        for (com.microsoft.embeddedsocial.autorest.models.ActivityView view : response.getData()) {
+            activities.add(new ActivityView(view));
+        }
+        // Update the deliveredActivityHandle to be the most recent activity handle
+        this.deliveredActivityHandle = (activities.isEmpty() ? "" : activities.get(0).getHandle());
         setContinuationKey(response.getCursor());
-	}
+    }
 
-	@Override
-	public List<ActivityView> getData() {
-		return activities != null ? activities : Collections.emptyList();
-	}
+    @Override
+    public List<ActivityView> getData() {
+        return activities != null ? activities : Collections.emptyList();
+    }
 
-	public String getDeliveredActivityHandle() {
-		return deliveredActivityHandle;
-	}
+    public String getDeliveredActivityHandle() {
+        return deliveredActivityHandle;
+    }
 }

--- a/EmbeddedSocialClient/sdk/src/main/java/com/microsoft/embeddedsocial/server/model/notification/GetNotificationFeedResponse.java
+++ b/EmbeddedSocialClient/sdk/src/main/java/com/microsoft/embeddedsocial/server/model/notification/GetNotificationFeedResponse.java
@@ -22,16 +22,16 @@ public class GetNotificationFeedResponse extends FeedUserResponse implements Lis
 
 	public GetNotificationFeedResponse(List<ActivityView> activities) {
 		this.activities = activities;
-		this.deliveredActivityHandle = activities.get(0).getHandle();
+		this.deliveredActivityHandle = (activities.isEmpty() ? "" : activities.get(0).getHandle());
 	}
 
 	public GetNotificationFeedResponse (FeedResponseActivityView response) {
 		activities = new ArrayList<>();
 		for (com.microsoft.embeddedsocial.autorest.models.ActivityView view : response.getData()) {
 			activities.add(new ActivityView(view));
-			// Update the deliveredActivityHandle to be the most recent activity handle
-			this.deliveredActivityHandle = (activities.isEmpty() ? "" : activities.get(0).getHandle());
 		}
+		// Update the deliveredActivityHandle to be the most recent activity handle
+		this.deliveredActivityHandle = (activities.isEmpty() ? "" : activities.get(0).getHandle());
         setContinuationKey(response.getCursor());
 	}
 

--- a/EmbeddedSocialClient/sdk/src/main/java/com/microsoft/embeddedsocial/server/model/notification/GetNotificationFeedResponse.java
+++ b/EmbeddedSocialClient/sdk/src/main/java/com/microsoft/embeddedsocial/server/model/notification/GetNotificationFeedResponse.java
@@ -32,6 +32,7 @@ public class GetNotificationFeedResponse extends FeedUserResponse implements Lis
 			activities.add(new ActivityView(view));
 		}
 		this.deliveredActivityHandle = "";
+        setContinuationKey(response.getCursor());
 	}
 
 	@Override

--- a/EmbeddedSocialClient/sdk/src/main/java/com/microsoft/embeddedsocial/server/model/notification/GetNotificationFeedResponse.java
+++ b/EmbeddedSocialClient/sdk/src/main/java/com/microsoft/embeddedsocial/server/model/notification/GetNotificationFeedResponse.java
@@ -17,21 +17,21 @@ import java.util.List;
 public class GetNotificationFeedResponse extends FeedUserResponse implements ListResponse<ActivityView> {
 
 	private List<ActivityView> activities;
+	// Setting this handle is required to properly update the "last-read" notification
 	private String deliveredActivityHandle;
 
 	public GetNotificationFeedResponse(List<ActivityView> activities) {
 		this.activities = activities;
-
-		// FIXME fix setting this handle
-		this.deliveredActivityHandle = "";
+		this.deliveredActivityHandle = activities.get(0).getHandle();
 	}
 
 	public GetNotificationFeedResponse (FeedResponseActivityView response) {
 		activities = new ArrayList<>();
 		for (com.microsoft.embeddedsocial.autorest.models.ActivityView view : response.getData()) {
 			activities.add(new ActivityView(view));
+			// Update the deliveredActivityHandle to be the most recent activity handle
+			this.deliveredActivityHandle = (activities.isEmpty() ? "" : activities.get(0).getHandle());
 		}
-		this.deliveredActivityHandle = "";
         setContinuationKey(response.getCursor());
 	}
 


### PR DESCRIPTION
The first commit change (to FeedUserResponse and NotificationFeedREsponse) allows custom FeedResponses to set their continuation key so that the fetcher (or recipient) of the feed response can actually continue to fetch pages from the place they left off. This change is only made to the NotificationFeedResponse at the moment; similar changes should be made to the comment and reply feed responses (and other such feeds) if this functionality is desired.

The second commit change to GetNotificationFeedResponse sets the DeliveredActivityHandle properly. However, see the commit message as to why this still doesn't update read notifications properly.