### PR TITLE
Move the accent color definition from the config file to the colors.x…

### DIFF
--- a/EmbeddedSocialClient/app/src/main/res/raw/embedded_social_config
+++ b/EmbeddedSocialClient/app/src/main/res/raw/embedded_social_config
@@ -27,7 +27,6 @@
 		}
 	},
 	"theme" : {
-		"accentColor" : "FF4CAF50",
 		"name" : "light"
 	}
 }

--- a/EmbeddedSocialClient/sdk/src/main/java/com/microsoft/embeddedsocial/sdk/Options.java
+++ b/EmbeddedSocialClient/sdk/src/main/java/com/microsoft/embeddedsocial/sdk/Options.java
@@ -5,9 +5,9 @@
 
 package com.microsoft.embeddedsocial.sdk;
 
-import android.text.TextUtils;
-
 import com.microsoft.embeddedsocial.ui.theme.ThemeGroup;
+
+import android.text.TextUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -28,7 +28,6 @@ public final class Options {
 	void verify() {
 		checkValueIsNotNull("application", application);
 		checkValueIsNotNull("socialNetworks", socialNetworks);
-		checkValueIsNotNull("name", theme);
 		checkValueIsNotNull("socialNetworks.facebook", socialNetworks.facebook);
 		checkValueIsNotNull("socialNetworks.twitter", socialNetworks.twitter);
 		checkValueIsNotNull("socialNetworks.google", socialNetworks.google);
@@ -38,7 +37,6 @@ public final class Options {
 		checkValueIsNotEmpty("socialNetworks.facebook.clientId", socialNetworks.facebook.clientId);
 		checkValueIsNotEmpty("socialNetworks.microsoft.clientId", socialNetworks.microsoft.clientId);
 		checkValueIsNotEmpty("socialNetworks.google.clientId", socialNetworks.google.clientId);
-		checkValueIsNotNull("theme.accentColor", theme.accentColor);
 
 		if (application.numberOfCommentsToShow <= 0) {
 			throwInvalidConfigException("application.numberOfCommentsToShow must be greater then 0");
@@ -134,12 +132,8 @@ public final class Options {
 		return socialNetworks.google.clientId;
 	}
 
-	public int getAccentColor() {
-		return (int) Long.parseLong(theme.accentColor, 16);
-	}
-
 	public ThemeGroup getThemeGroup() {
-		return theme.name == null ? ThemeGroup.LIGHT : theme.name;
+		return (theme == null || theme.name == null) ? ThemeGroup.LIGHT : theme.name;
 	}
 
 	/**
@@ -180,7 +174,6 @@ public final class Options {
 	}
 
 	private class DrawTheme {
-		private String accentColor;
 		private ThemeGroup name;
 	}
 }

--- a/EmbeddedSocialClient/sdk/src/main/java/com/microsoft/embeddedsocial/ui/util/ButtonStyleHelper.java
+++ b/EmbeddedSocialClient/sdk/src/main/java/com/microsoft/embeddedsocial/ui/util/ButtonStyleHelper.java
@@ -5,8 +5,6 @@
 
 package com.microsoft.embeddedsocial.ui.util;
 
-import com.microsoft.embeddedsocial.base.GlobalObjectRegistry;
-import com.microsoft.embeddedsocial.sdk.Options;
 import com.microsoft.embeddedsocial.sdk.R;
 
 import android.content.Context;
@@ -36,7 +34,7 @@ public class ButtonStyleHelper {
 		greenColor = res.getColorStateList(R.color.es_button_text_green);
 		grayColor = res.getColorStateList(R.color.es_button_text_gray);
 		redColor = res.getColorStateList(R.color.es_pink_500);
-		accentColor = GlobalObjectRegistry.getObject(Options.class).getAccentColor();
+		accentColor = res.getColor(R.color.es_accent_color);
 	}
 
 	public void applyGreenCompletedStyle(TextView view) {

--- a/EmbeddedSocialClient/sdk/src/main/res/values/colors.xml
+++ b/EmbeddedSocialClient/sdk/src/main/res/values/colors.xml
@@ -60,4 +60,5 @@
 	<color name="es_sign_in_twitter">#1da1f2</color>
 
 	<color name="es_status_bar">@color/es_text_secondary_light</color>
+	<color name="es_accent_color">#FF4CAF50</color>
 </resources>


### PR DESCRIPTION
…ml file. Hosting apps can set the accent color by overriding it in their colors.xml file.

This allows hosting applications to set a different ES accent color per build flavor.