### PR TITLE
removed signing configs to bypass build errors

### DIFF
--- a/EmbeddedSocialClient/sampleapp/build.gradle
+++ b/EmbeddedSocialClient/sampleapp/build.gradle
@@ -20,11 +20,6 @@ repositories {
 }
 
 android {
-    signingConfigs {
-        debug {
-            storeFile file('debug.keystore')
-        }
-    }
     compileSdkVersion 26
     buildToolsVersion '26.0.2'
     defaultConfig {


### PR DESCRIPTION
Couldn't build sample app unless I removed the signing configs block.