### PR TITLE
Remove permissions previously required by GCM but not required by FCM

### DIFF
--- a/EmbeddedSocialClient/app/src/main/AndroidManifest.xml
+++ b/EmbeddedSocialClient/app/src/main/AndroidManifest.xml
@@ -13,15 +13,6 @@
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
-
-    <permission
-        android:name="com.microsoft.embeddedsocial.permission.C2D_MESSAGE"
-        android:protectionLevel="signature"
-        />
-
-    <uses-permission android:name="com.google.android.c2dm.permission.RECEIVE"/>
-    <uses-permission android:name="com.microsoft.embeddedsocial.permission.C2D_MESSAGE"/>
-    <uses-permission android:name="android.permission.WAKE_LOCK"/>
     <uses-permission android:name="android.permission.GET_ACCOUNTS" />
     <uses-permission android:name="android.permission.USE_CREDENTIALS" />
 


### PR DESCRIPTION
This follows step 3 of the GCM to FCM upgrade instructions.  https://developers.google.com/cloud-messaging/android/android-migrate-fcm